### PR TITLE
update cache loading to allow for removing double fetchs when request is already in flight

### DIFF
--- a/packages/client/src/client/FinchClient.test.ts
+++ b/packages/client/src/client/FinchClient.test.ts
@@ -101,12 +101,12 @@ describe('FinchClient', () => {
       expect(browser.runtime.connect).toHaveBeenCalledTimes(1);
       await client.query('query foo { bar }');
       const timeoutPendingQuery = client.query(
-        'query foo { bar }',
+        'query bar { baz }',
         {},
         { timeout: 100 },
       );
       const pendingQuery = client.query(
-        'query foo { bar }',
+        'query baz { qux }',
         {},
         { timeout: 1000 },
       );

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -270,6 +270,11 @@ export class FinchClient {
       (options.cachePolicy ?? this.cachePolicy) === FinchCachePolicy.CacheFirst;
 
     const snapshot = cache?.getSnapshot();
+
+    if (snapshot.loading) {
+      return snapshot;
+    }
+
     if (!snapshot.data && !snapshot.errors) {
       cache.update({
         ...snapshot,

--- a/packages/client/src/client/FinchClient.ts
+++ b/packages/client/src/client/FinchClient.ts
@@ -275,7 +275,7 @@ export class FinchClient {
       return snapshot;
     }
 
-    if (!snapshot.data && !snapshot.errors) {
+    if (!snapshot.data && !snapshot.errors && !snapshot.loading) {
       cache.update({
         ...snapshot,
         cacheStatus: FinchCacheStatus.Fresh,

--- a/packages/client/src/client/cache/QueryCache.ts
+++ b/packages/client/src/client/cache/QueryCache.ts
@@ -58,7 +58,7 @@ export class QueryCache implements FinchCache {
       cache = new Observable<FinchQueryResults<Query>>({
         data: undefined,
         errors: undefined,
-        loading: true,
+        loading: false,
         cacheStatus: FinchCacheStatus.Unknown,
       });
       this.store.set(key, cache);


### PR DESCRIPTION
## Description

<!--
  Description: [REQUIRED]
  Please include a summary of the feature and the change which were created
  to ensure readers of this pull request know what they are looking at.
-->

This PR makes sure that if there is already an outbound request happening use that request instead of making a new one. This is done by checking the loading state of the cache. There was some defaults in the cache that have been updated to support this.

## Testing

<!--
  Testing: [Required]
  If you did not write any tests that are in your code please describe how
  you ensured this code does what the description says it does. You may be
  asked in the PR how you tested the feature if you do not fill this out.
-->

- [ ] Includes test.
- [x] Manually tested.

## Additional notes

<!--
  Additional notes: [Optional]
  Anything additional like if you had to refactor something, or if
  an additional dependency is being added and why.
-->

_No additional information is given_
